### PR TITLE
Collect gRPC info: search for Microsoft.AspNetCore.Hosting.HttpRequestIn Activity

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -243,13 +243,20 @@ namespace Elastic.Apm.AspNetCore
 		/// <returns>default if it's not a grpc call, otherwise the Grpc method name and result as a tuple </returns>
 		private static (string methodname, string result) CollectGrpcInfo()
 		{
-			var parentActivity = Activity.Current?.Parent;
+			// gRPC info is stored on the Activity with name `Microsoft.AspNetCore.Hosting.HttpRequestIn`.
+			// Therefore we follow parent activities as long as we reach this activity.
+			// Activity.Current can e.g. be the `ElasticApm.Transaction` Activity, so we need to go up the activity chain.
+			var httpRequestInActivity = Activity.Current;
+
+			while (httpRequestInActivity?.DisplayName != "Microsoft.AspNetCore.Hosting.HttpRequestIn" && httpRequestInActivity != null)
+				httpRequestInActivity = httpRequestInActivity.Parent;
+
 			(string methodname, string result) grpcCallInfo = default;
 
-			if (parentActivity != null)
+			if (httpRequestInActivity != null)
 			{
-				var grpcMethodName = parentActivity.Tags.FirstOrDefault(n => n.Key == "grpc.method").Value;
-				var grpcStatusCode = parentActivity.Tags.FirstOrDefault(n => n.Key == "grpc.status_code").Value;
+				var grpcMethodName = httpRequestInActivity.Tags.FirstOrDefault(n => n.Key == "grpc.method").Value;
+				var grpcStatusCode = httpRequestInActivity.Tags.FirstOrDefault(n => n.Key == "grpc.status_code").Value;
 
 				if (!string.IsNullOrEmpty(grpcMethodName) && !string.IsNullOrEmpty(grpcStatusCode))
 					grpcCallInfo = (grpcMethodName, grpcStatusCode);

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -248,7 +248,7 @@ namespace Elastic.Apm.AspNetCore
 			// Activity.Current can e.g. be the `ElasticApm.Transaction` Activity, so we need to go up the activity chain.
 			var httpRequestInActivity = Activity.Current;
 
-			while (httpRequestInActivity?.DisplayName != "Microsoft.AspNetCore.Hosting.HttpRequestIn" && httpRequestInActivity != null)
+			while (httpRequestInActivity?.OperationName != "Microsoft.AspNetCore.Hosting.HttpRequestIn" && httpRequestInActivity != null)
 				httpRequestInActivity = httpRequestInActivity.Parent;
 
 			(string methodname, string result) grpcCallInfo = default;


### PR DESCRIPTION
Follow up from https://github.com/elastic/apm-agent-dotnet/pull/1228 

I looked into the failing gRPC tests.

gRPC info [is stored on an Activity called `Microsoft.AspNetCore.Hosting.HttpRequestIn`](https://docs.microsoft.com/en-us/aspnet/core/grpc/diagnostics?view=aspnetcore-5.0#grpc-service-tracing). Prior to https://github.com/elastic/apm-agent-dotnet/pull/1228 we always created an Activity and `Microsoft.AspNetCore.Hosting.HttpRequestIn` was always its parent (although I think this assumption was already way too optimistic). Now with https://github.com/elastic/apm-agent-dotnet/pull/1228  the agent either creates and Activity or reuses an existing one.

Therefore this PR always searches up the Activity chain up to `Microsoft.AspNetCore.Hosting.HttpRequestIn` to read the `Tags` on it which contains the gRPC info that we collect instead of hard-coding `Activity.Current.Parent` and reads its tags.